### PR TITLE
Temporarily disable possible protection against XXE exploits

### DIFF
--- a/src/API/ExchangeWebServices.php
+++ b/src/API/ExchangeWebServices.php
@@ -266,12 +266,14 @@ class ExchangeWebServices
         $this->server = $server;
         $this->version = $options['version'];
 
+	    $backup = libxml_disable_entity_loader(true);
         $this->soap = new NTLMSoapClient(
             $location,
             $auth,
             dirname(__FILE__) . '/../../Resources/wsdl/services.wsdl',
             $options
         );
+	    libxml_disable_entity_loader($backup);
 
         if (isset($options['primarySmtpEmailAddress'])) {
             $this->setPrimarySmtpEmailAddress($options['primarySmtpEmailAddress']);

--- a/src/API/ExchangeWebServices.php
+++ b/src/API/ExchangeWebServices.php
@@ -266,14 +266,14 @@ class ExchangeWebServices
         $this->server = $server;
         $this->version = $options['version'];
 
-	    $backup = libxml_disable_entity_loader(false);
+        $backup = libxml_disable_entity_loader(false);
         $this->soap = new NTLMSoapClient(
             $location,
             $auth,
             dirname(__FILE__) . '/../../Resources/wsdl/services.wsdl',
             $options
         );
-	    libxml_disable_entity_loader($backup);
+        libxml_disable_entity_loader($backup);
 
         if (isset($options['primarySmtpEmailAddress'])) {
             $this->setPrimarySmtpEmailAddress($options['primarySmtpEmailAddress']);

--- a/src/API/ExchangeWebServices.php
+++ b/src/API/ExchangeWebServices.php
@@ -266,7 +266,7 @@ class ExchangeWebServices
         $this->server = $server;
         $this->version = $options['version'];
 
-	    $backup = libxml_disable_entity_loader(true);
+	    $backup = libxml_disable_entity_loader(false);
         $this->soap = new NTLMSoapClient(
             $location,
             $auth,

--- a/tests/src/API/TypeTest.php
+++ b/tests/src/API/TypeTest.php
@@ -54,7 +54,6 @@ class TypeTest extends PHPUnit_Framework_TestCase
         } else {
             $calendarItem->{$callName}($value);
         }
-
     }
 
     /**


### PR DESCRIPTION
See https://www.sensepost.com/blog/2014/revisting-xxe-and-abusing-protocols/

For more info.

Basically, it's recommended to call the next method at the beginning of your application, any application.
libxml_disable_entity_loader(true);

Since we need the loading of a wsdl file here, we need to temporarily enable the loader again in case it has been disabled. After that, gentleman as we are, we reset the setting to its original state.