### PR TITLE
Attach response to ExchangeException when getting items

### DIFF
--- a/src/API/Exception/ExchangeException.php
+++ b/src/API/Exception/ExchangeException.php
@@ -3,8 +3,28 @@
 namespace garethp\ews\API\Exception;
 
 use garethp\ews\API;
+use garethp\ews\API\Message\ResponseMessageType;
 
 class ExchangeException extends API\Exception
 {
+    /**
+     * @var ResponseMessageType
+     */
+    private $response;
 
+    /**
+     * @param ResponseMessageType $response
+     */
+    public function setResponse(ResponseMessageType $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return ResponseMessageType
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }

--- a/src/API/ExchangeWebServices.php
+++ b/src/API/ExchangeWebServices.php
@@ -417,7 +417,10 @@ class ExchangeWebServices
 
         if ($response instanceof Message\ResponseMessageType) {
             if ($response->getResponseClass() !== "Success") {
-                throw new ExchangeException($response->getMessageText());
+                $exception = new ExchangeException($response->getMessageText());
+                $exception->setResponse($response);
+
+                throw $exception;
             }
 
             unset($items['responseClass']);


### PR DESCRIPTION
When drilldown is enabled and an error occurs (`$response->getResponseClass() !== "Success"`), an exception is thrown. In this case, it becomes impossible to access certain information related to the error, for example, the `responseCode`.

This PR addresses this limitation by attaching the `Response` to the `ExchangeException`.