### PR TITLE
Update ExchangeAutodiscover.php

### DIFF
--- a/src/API/ExchangeAutodiscover.php
+++ b/src/API/ExchangeAutodiscover.php
@@ -393,6 +393,6 @@ XML;
             return ExchangeWebServices::VERSION_2016;
         }
 
-        return $buildVersion == 847 ? ExchangeWebServices::VERSION_2013_SP1 : ExchangeWebServices::VERSION_2013;
+        return $buildVersion >= 847 ? ExchangeWebServices::VERSION_2013_SP1 : ExchangeWebServices::VERSION_2013;
     }
 }


### PR DESCRIPTION
I've faced a problem in the function (class : src/API/ExchangeAutodiscover.php):
protected function parseVersionAfter2013($majorVersion, $minorVersion, $buildVersion)
{
if ($minorVersion >= 1) {
return ExchangeWebServices::VERSION_2016;
}

return $buildVersion == 847 ? ExchangeWebServices::VERSION_2013_SP1 : ExchangeWebServices::VERSION_2013;
}`
It seems that not only build 847 is version SP1 but version SP1 and UPPER according to build history versions :
https://technet.microsoft.com/fr-fr/library/hh135098(v=exchg.150).aspx#Exchange%20Server%C2%A02013

So the correct code must be :
$buildVersion >= 847 ? ExchangeWebServices::VERSION_2013_SP1 : ExchangeWebServices::VERSION_2013; }