### PR TITLE
Add gitattributes file to not pull down tests on each install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Ignore all test and examples with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/tests              export-ignore
+/examples           export-ignore


### PR DESCRIPTION
Not 100% sure if this is right yet, but ideally we don't need to pull down tests and example folders when doing a composer install.

(Like mentioned in https://medium.com/@pablorsk/be-a-git-ninja-the-gitattributes-file-e58c07c9e915#8306)

One bit I'm not sure on is that the test are autoloaded with psr4 (in composer.json) not sure how to test if this will throw an error. (Do they need to be autoloaded?).

But thought I'd create the PR anyway, if it's useful