### PR TITLE
Enclose FreeBusyResponse in an array in areAvailable

### DIFF
--- a/src/CalendarAPI.php
+++ b/src/CalendarAPI.php
@@ -311,7 +311,7 @@ class CalendarAPI extends API
 
         $availabilities = array_map(function (FreeBusyResponseType $freeBusyResponseType) {
             return str_split($freeBusyResponseType->getFreeBusyView()->getMergedFreeBusy());
-        }, $availability->getFreeBusyResponseArray()->FreeBusyResponse);
+        }, array($availability->getFreeBusyResponseArray()->FreeBusyResponse));
 
         foreach ($availabilities[0] as $periodIndex => $availability) {
             if ($availability != 0) {


### PR DESCRIPTION
In the current master branc areAvailable fails with error 
PHP Warning:  array_map(): Expected parameter 2 to be an array, object given in ../vendor/garethp/php-ews/src/CalendarAPI.php on line 314

This is due to the second argument to the array_map function not being an array. 
