### PR TITLE
Fix DistinguishedFolderIds not respecting PrimarySmtpMailbox (#276)

### DIFF
--- a/src/API/Type/DistinguishedFolderIdType.php
+++ b/src/API/Type/DistinguishedFolderIdType.php
@@ -35,7 +35,7 @@ class DistinguishedFolderIdType extends BaseFolderIdType
 
     public function toArray($getOuterArray = false)
     {
-        $id = [ 'Id' => $this->id, 'ChangeKey' => $this->changeKey ];
+        $id = [ 'Id' => $this->id, 'ChangeKey' => $this->changeKey, 'Mailbox' => $this->mailbox ];
 
         if ($getOuterArray === true) {
             return ['DistinguishedFolderId' => $id];

--- a/src/BuildableTrait.php
+++ b/src/BuildableTrait.php
@@ -75,7 +75,7 @@ trait BuildableTrait
                     $classToBuild = $parameters[0]->getClass()->getName();
 
                     $newValue = call_user_func("$classToBuild::buildFromArray", $value, true);
-                    $object->$key = $newValue;
+                    $object->{ucfirst($key)} = $newValue;
                     continue;
                 }
             }
@@ -89,7 +89,11 @@ trait BuildableTrait
                 $key = "_";
             }
 
-            $object->$key = $value;
+            if ($value instanceof Type) {
+                $value = $value->toXmlObject();
+            }
+
+            $object->{ucfirst($key)} = $value;
         }
 
         return $object;

--- a/tests/src/API/TypeTest.php
+++ b/tests/src/API/TypeTest.php
@@ -118,8 +118,8 @@ class TypeTest extends TestCase
         ]);
         $type->_value = 'value';
 
-        $this->assertSame(['test' => 'test'], $type->getNonNullItems());
-        $this->assertSame(['test' => 'test', '_value' => 'value'], $type->getNonNullItems(true));
+        $this->assertSame(['Test' => 'test'], $type->getNonNullItems());
+        $this->assertSame(['Test' => 'test', '_value' => 'value'], $type->getNonNullItems(true));
     }
 
     public static function arrayAssocProvider()


### PR DESCRIPTION
This solves the DistinguishedFOlderIdType not holding onto it's primary smtp mailbox by passing it in the `toArray()` method and fixing `BuildableTrait` to convert **all** nested `Type` objects into `XmlObject` and making sure all keys are uppercased

This should solve (#276)