### PR TITLE
PHP 8.4 fixes

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -22,7 +22,7 @@ class API
         'version' => ExchangeWebServices::VERSION_2010
     );
 
-    public function __construct(ExchangeWebServices $client = null)
+    public function __construct(?ExchangeWebServices $client = null)
     {
         if ($client) {
             $this->setClient($client);
@@ -180,7 +180,7 @@ class API
         return Utilities\ensureIsArray($response);
     }
 
-    public function createCalendars($names, BaseFolderIdType $parentFolder = null, $options = array())
+    public function createCalendars($names, ?BaseFolderIdType $parentFolder = null, $options = array())
     {
         if ($parentFolder === null) {
             $parentFolder = $this->getDistinguishedFolderId('calendar');
@@ -189,7 +189,7 @@ class API
         return $this->createFolders($names, $parentFolder, $options, 'IPF.Appointment');
     }
 
-    public function createContactsFolder($names, BaseFolderIdType $parentFolder = null, $options = array())
+    public function createContactsFolder($names, ?BaseFolderIdType $parentFolder = null, $options = array())
     {
         if ($parentFolder === null) {
             $parentFolder = $this->getDistinguishedFolderId('contacts');

--- a/src/API/Exception/ExchangeException.php
+++ b/src/API/Exception/ExchangeException.php
@@ -13,7 +13,7 @@ class ExchangeException extends API\Exception
      */
     private $response;
 
-    public function __construct(ResponseMessageType $response, $code = 0, Throwable $previous = null)
+    public function __construct(ResponseMessageType $response, $code = 0, ?Throwable $previous = null)
     {
         $this->response = $response;
         parent::__construct($response->getMessageText(), $code, $previous);

--- a/src/API/Type/DistinguishedFolderIdType.php
+++ b/src/API/Type/DistinguishedFolderIdType.php
@@ -26,7 +26,7 @@ class DistinguishedFolderIdType extends BaseFolderIdType
      */
     protected $mailbox = null;
 
-    public function __construct($id = null, $changeKey = null, EmailAddressType $mailbox = null)
+    public function __construct($id = null, $changeKey = null, ?EmailAddressType $mailbox = null)
     {
         $this->id = $id;
         $this->changeKey = $changeKey;


### PR DESCRIPTION
Fix deprecations in php8.4
Like this one
```
Deprecated: garethp\ews\API::createContactsFolder(): Implicitly marking parameter $parentFolder as nullable is deprecated, the explicit nullable type must be used instead
```