### PR TITLE
PHP 8.5 - Fix SoapClient doRequest

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
     name: PHP ${{ matrix.php }}
     steps:
       - name: Checkout

--- a/src/API/NTLMSoapClient.php
+++ b/src/API/NTLMSoapClient.php
@@ -187,10 +187,11 @@ class NTLMSoapClient extends SoapClient
      * @param string $action the soap action.
      * @param integer $version the soap version
      * @param integer $one_way
+     * @param string $uriParserClass
      * @return string the xml soap response.
      */
     #[\ReturnTypeWillChange]
-    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    public function __doRequest($request, $location, $action, $version, $one_way = 0, ?string $uriParserClass = null)
     {
         $postOptions = array(
             'body' => $request,


### PR DESCRIPTION
Hi,

First of all thanks for this great project.
After upgrading to PHP 8.5, I couldn't create a calendar event.

I noticed that PHP 8.5 added a breaking change for `__doRequest` in `SOAPClient` ([see this issue](https://github.com/php/php-src/issues/20274)). I solved it by adding the new parameter.
It seems to also work with PHP 8.4.